### PR TITLE
Update plugin to allow installing flow classifiers

### DIFF
--- a/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnRedirectionApi.java
+++ b/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnRedirectionApi.java
@@ -90,7 +90,7 @@ public class NeutronSfcSdnRedirectionApi implements SdnRedirectionApi {
 
         String inspectionPortGroupId = inspectionPort.getParentId();
         if (inspectionPortGroupId != null) {
-            PortPairGroupEntity ppg = this.utils.findByPortgroupId(inspectionPortGroupId);
+            PortPairGroupEntity ppg = this.utils.findByPortPairgroupId(inspectionPortGroupId);
 
             //If Port group does not exist throw an exception
             if (ppg == null) {
@@ -132,11 +132,15 @@ public class NeutronSfcSdnRedirectionApi implements SdnRedirectionApi {
             return;
         }
 
-        // should remove ppg if applicable
         InspectionPortElement foundInspectionPort = getInspectionPort(inspectionPort);
 
         if (foundInspectionPort != null) {
+            PortPairGroupEntity ppg = ((InspectionPortEntity) foundInspectionPort).getPortPairGroup();
             this.utils.removeSingleInspectionPort(foundInspectionPort.getElementId());
+            ppg.getPortPairs().remove(foundInspectionPort);
+            if(ppg.getPortPairs().size() == 0) {
+                this.utils.removePortPairGroup(ppg.getElementId());
+            }
         } else {
             NetworkElement ingress = inspectionPort.getIngressPort();
             NetworkElement egress = inspectionPort.getEgressPort();
@@ -147,7 +151,6 @@ public class NeutronSfcSdnRedirectionApi implements SdnRedirectionApi {
     }
 
     // Inspection Hooks methods
-
     @Override
     public String installInspectionHook(NetworkElement inspectedPort, InspectionPortElement inspectionPort, Long tag,
             TagEncapsulationType encType, Long order, FailurePolicyType failurePolicyType)

--- a/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnRedirectionApi.java
+++ b/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnRedirectionApi.java
@@ -164,7 +164,7 @@ public class NeutronSfcSdnRedirectionApi implements SdnRedirectionApi {
             throw new IllegalArgumentException("Attempt to install an Inspection Hook with null Inspection Port");
         }
 
-        LOG.info(String.format("Installing Inspection Hook for (Inspected %s ; Inspection Port %s):",
+        LOG.info(String.format("Installing Inspection Hook for (Inspected Port %s ; Inspection Port %s):",
                 "" + inspectedPort, "" + inspectionPort));
 
         InspectionHookEntity retValEntity = this.txControl.required(() -> {
@@ -177,7 +177,7 @@ public class NeutronSfcSdnRedirectionApi implements SdnRedirectionApi {
             if (inspectionHookEntity == null) {
                 inspectionHookEntity = this.utils.makeInspectionHookEntity(inspectedPort, sfc);
             } else {
-                String msg = String.format("Found existing inspection hook (Inspected %s ; Inspection Port %s)",
+                String msg = String.format("Found existing inspection hook (Inspected Port %s ; Inspection Port %s)",
                         inspectedPort, inspectionPort);
                 LOG.error(msg);
                 throw new IllegalStateException(msg);

--- a/src/main/java/org/osc/controller/nsfc/entities/InspectionHookEntity.java
+++ b/src/main/java/org/osc/controller/nsfc/entities/InspectionHookEntity.java
@@ -16,13 +16,11 @@
  *******************************************************************************/
 package org.osc.controller.nsfc.entities;
 
-import static javax.persistence.EnumType.STRING;
 import static javax.persistence.FetchType.EAGER;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -34,6 +32,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.osc.sdk.controller.FailurePolicyType;
 import org.osc.sdk.controller.TagEncapsulationType;
 import org.osc.sdk.controller.element.InspectionHookElement;
+import org.osc.sdk.controller.element.InspectionPortElement;
 
 @Entity
 @Table(name = "INSPECTION_HOOK")
@@ -45,29 +44,20 @@ public class InspectionHookEntity implements InspectionHookElement {
     @Column(name = "hook_id", unique = true)
     private String hookId;
 
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = false, fetch = EAGER, optional = true)
-    @JoinColumn(name = "inspected_port_fk", nullable = true, updatable = true)
+    @OneToOne(fetch = EAGER, cascade = CascadeType.ALL)
+    @JoinColumn(name = "inspected_port_fk", nullable = false)
     private NetworkElementEntity inspectedPort;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH}, fetch = EAGER, optional = true)
-    @JoinColumn(name = "inspection_port_fk", nullable = true, updatable = true)
-    private InspectionPortEntity inspectionPort;
+    @ManyToOne(fetch = EAGER)
+    @JoinColumn(name = "sfc_fk", nullable = false)
+    private ServiceFunctionChainEntity serviceFunctionChain;
 
-    private Long tag;
+    InspectionHookEntity() {
+    }
 
-    // "order" is a sql keyword. Avoid column named "order"
-    @Column(name = "hook_order")
-    private Long hookOrder;
-
-    @Enumerated(STRING)
-    @Column(name = "enc_type")
-    private TagEncapsulationType encType;
-
-    @Enumerated(STRING)
-    @Column(name = "failure_policy_type")
-    private FailurePolicyType failurePolicyType;
-
-    public InspectionHookEntity() {
+    public InspectionHookEntity(NetworkElementEntity inspectedPort, ServiceFunctionChainEntity serviceFunctionChain) {
+        this.inspectedPort = inspectedPort;
+        this.serviceFunctionChain = serviceFunctionChain;
     }
 
     @Override
@@ -88,55 +78,43 @@ public class InspectionHookEntity implements InspectionHookElement {
         this.inspectedPort = inspectedPort;
     }
 
-    @Override
-    public InspectionPortEntity getInspectionPort() {
-        return this.inspectionPort;
+    public ServiceFunctionChainEntity getServiceFunctionChain() {
+        return this.serviceFunctionChain;
     }
 
-    public void setInspectionPort(InspectionPortEntity inspectionPort) {
-        this.inspectionPort = inspectionPort;
+    public void setServiceFunctionChain(ServiceFunctionChainEntity serviceFunctionChain) {
+        this.serviceFunctionChain = serviceFunctionChain;
     }
 
     @Override
     public Long getTag() {
-        return this.tag;
-    }
-
-    public void setTag(Long tag) {
-        this.tag = tag;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Long getOrder() {
-        return this.hookOrder;
-    }
-
-    public void setOrder(Long order) {
-        this.hookOrder = order;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public TagEncapsulationType getEncType() {
-        return this.encType;
-    }
-
-    public void setEncType(TagEncapsulationType encType) {
-        this.encType = encType;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public FailurePolicyType getFailurePolicyType() {
-        return this.failurePolicyType;
-    }
-
-    public void setFailurePolicyType(FailurePolicyType failurePolicyType) {
-        this.failurePolicyType = failurePolicyType;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String toString() {
-        return "InspectionHookEntity [hookId=" + this.hookId + ", inspectedPort=" + this.inspectedPort +
-               ", tag=" + this.tag + ", hookOrder=" + this.hookOrder + ", encType=" + this.encType
-               + ", failurePolicyType=" + this.failurePolicyType + "]";
+        return "InspectionHookEntity [hookId=" + this.hookId + ", inspectedPort=" + this.inspectedPort
+                + ", serviceFunctionChain=" + this.serviceFunctionChain + "]";
     }
+
+    @Override
+    public InspectionPortElement getInspectionPort() {
+        return null;
+    }
+
 }

--- a/src/main/java/org/osc/controller/nsfc/entities/InspectionPortEntity.java
+++ b/src/main/java/org/osc/controller/nsfc/entities/InspectionPortEntity.java
@@ -18,10 +18,6 @@ package org.osc.controller.nsfc.entities;
 
 import static javax.persistence.FetchType.EAGER;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -31,7 +27,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -69,9 +64,6 @@ public class InspectionPortEntity implements InspectionPortElement {
             foreignKey = @ForeignKey(name = "FK_INSPECTION_PORT_NETWORK_ELEMENT_EGR"))
     private NetworkElementEntity egressPort;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = false, fetch = EAGER, mappedBy="inspectionPort")
-    private Set<InspectionHookEntity> inspectionHooks = new HashSet<>();
-
     public InspectionPortEntity() {
     }
 
@@ -80,7 +72,6 @@ public class InspectionPortEntity implements InspectionPortElement {
         this.portPairGroup = portPairGroup;
         this.ingressPort = ingress;
         this.egressPort = egress;
-        this.inspectionHooks = new HashSet<>();
     }
 
     @Override
@@ -106,14 +97,6 @@ public class InspectionPortEntity implements InspectionPortElement {
         this.egressPort = egressPort;
     }
 
-    public Set<InspectionHookEntity> getInspectionHooks() {
-        return this.inspectionHooks;
-    }
-
-    public void setInspectionHooks(Collection<InspectionHookEntity> inspectionHooks) {
-        this.inspectionHooks = new HashSet<>(inspectionHooks);
-    }
-
     public PortPairGroupEntity getPortPairGroup() {
         return this.portPairGroup;
     }
@@ -131,8 +114,7 @@ public class InspectionPortEntity implements InspectionPortElement {
     public String toString() {
         // use get elementid on ppg to avoid cyclic dependency and stackoverflow issues
         return "InspectionPortEntity [elementId=" + this.elementId + ", portPairGroup=" + getParentId()
-                + ", ingressPort=" + this.ingressPort + ", egressPort=" + this.egressPort + ", inspectionHooks="
-                + this.inspectionHooks + "]";
+                + ", ingressPort=" + this.ingressPort + ", egressPort=" + this.egressPort + "]";
     }
 
     @Override

--- a/src/main/java/org/osc/controller/nsfc/entities/InspectionPortEntity.java
+++ b/src/main/java/org/osc/controller/nsfc/entities/InspectionPortEntity.java
@@ -38,6 +38,9 @@ import javax.persistence.Table;
 import org.hibernate.annotations.GenericGenerator;
 import org.osc.sdk.controller.element.InspectionPortElement;
 
+/**
+ * Translates to a port pair in SFC
+ */
 @Entity
 @Table(name = "INSPECTION_PORT")
 public class InspectionPortEntity implements InspectionPortElement {
@@ -130,6 +133,36 @@ public class InspectionPortEntity implements InspectionPortElement {
         return "InspectionPortEntity [elementId=" + this.elementId + ", portPairGroup=" + getParentId()
                 + ", ingressPort=" + this.ingressPort + ", egressPort=" + this.egressPort + ", inspectionHooks="
                 + this.inspectionHooks + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((this.elementId == null) ? 0 : this.elementId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        InspectionPortEntity other = (InspectionPortEntity) obj;
+        if (this.elementId == null) {
+            if (other.elementId != null) {
+                return false;
+            }
+        } else if (!this.elementId.equals(other.elementId)) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/org/osc/controller/nsfc/entities/PortPairGroupEntity.java
+++ b/src/main/java/org/osc/controller/nsfc/entities/PortPairGroupEntity.java
@@ -76,8 +76,9 @@ public class PortPairGroupEntity implements NetworkElement {
 
     @Override
     public String toString() {
-        return "PortPairGroupEntity [elementId=" + this.elementId + ", portPairs=" + this.portPairs + ", serviceFunctionChain="
-                + this.serviceFunctionChain + "]";
+        // use get elementid on sfc to avoid cyclic dependency and stackoverflow issues
+        return "PortPairGroupEntity [elementId=" + this.elementId + ", portPairs=" + this.portPairs
+                + ", serviceFunctionChain=" + getParentId() + "]";
     }
 
     @Override

--- a/src/main/java/org/osc/controller/nsfc/entities/ServiceFunctionChainEntity.java
+++ b/src/main/java/org/osc/controller/nsfc/entities/ServiceFunctionChainEntity.java
@@ -16,9 +16,14 @@
  *******************************************************************************/
 package org.osc.controller.nsfc.entities;
 
-import java.util.ArrayList;
-import java.util.List;
+import static javax.persistence.FetchType.EAGER;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -29,11 +34,12 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.GenericGenerator;
+import org.osc.sdk.controller.element.InspectionPortElement;
 import org.osc.sdk.controller.element.NetworkElement;
 
 @Entity
 @Table(name = "SERVICE_FUNCTION_CHAIN")
-public class ServiceFunctionChainEntity implements NetworkElement {
+public class ServiceFunctionChainEntity implements NetworkElement, InspectionPortElement {
 
     @Id
     @GeneratedValue(generator = "uuid")
@@ -44,6 +50,9 @@ public class ServiceFunctionChainEntity implements NetworkElement {
     @OneToMany(mappedBy = "serviceFunctionChain", fetch = FetchType.EAGER)
     @OrderColumn(name = "ppg_order")
     private List<PortPairGroupEntity> portPairGroups = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = false, fetch = EAGER, mappedBy="serviceFunctionChain")
+    private Set<InspectionHookEntity> inspectionHooks = new HashSet<>();
 
     public ServiceFunctionChainEntity() {
     }
@@ -66,6 +75,10 @@ public class ServiceFunctionChainEntity implements NetworkElement {
         this.portPairGroups = portPairGroups;
     }
 
+    public Set<InspectionHookEntity> getInspectionHooks() {
+        return this.inspectionHooks;
+    }
+
     @Override
     public String toString() {
         return "ServiceFunctionChainEntity [elementId=" + this.elementId + ", portPairGroups=" + this.portPairGroups + "]";
@@ -83,6 +96,16 @@ public class ServiceFunctionChainEntity implements NetworkElement {
 
     @Override
     public List<String> getPortIPs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NetworkElement getIngressPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NetworkElement getEgressPort() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
+++ b/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
@@ -16,9 +16,6 @@
  *******************************************************************************/
 package org.osc.controller.nsfc.utils;
 
-import static org.osc.sdk.controller.FailurePolicyType.NA;
-import static org.osc.sdk.controller.TagEncapsulationType.VLAN;
-
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -32,8 +29,8 @@ import org.osc.controller.nsfc.entities.InspectionHookEntity;
 import org.osc.controller.nsfc.entities.InspectionPortEntity;
 import org.osc.controller.nsfc.entities.NetworkElementEntity;
 import org.osc.controller.nsfc.entities.PortPairGroupEntity;
-import org.osc.sdk.controller.FailurePolicyType;
-import org.osc.sdk.controller.TagEncapsulationType;
+import org.osc.controller.nsfc.entities.ServiceFunctionChainEntity;
+import org.osc.sdk.controller.element.Element;
 import org.osc.sdk.controller.element.InspectionPortElement;
 import org.osc.sdk.controller.element.NetworkElement;
 import org.osgi.service.transaction.control.TransactionControl;
@@ -61,7 +58,7 @@ public class RedirectionApiUtils {
     }
 
     public InspectionPortEntity makeInspectionPortEntity(InspectionPortElement inspectionPortElement) {
-        throwExceptionIfNullElement(inspectionPortElement);
+        throwExceptionIfNullElement(inspectionPortElement, "Ins");
 
         NetworkElement ingress = inspectionPortElement.getIngressPort();
         throwExceptionIfNullElement(ingress, "Null ingress element.");
@@ -83,45 +80,18 @@ public class RedirectionApiUtils {
     }
 
     public InspectionHookEntity makeInspectionHookEntity(NetworkElement inspectedPort,
-            InspectionPortElement inspectionPort, Long tag, TagEncapsulationType encType, Long order,
-            FailurePolicyType failurePolicyType) {
+            NetworkElement sfcNetworkElement) {
 
         throwExceptionIfNullElement(inspectedPort, "Null inspected port!");
 
-        InspectionPortEntity inspectionPortEntity = makeInspectionPortEntity(inspectionPort);
-
-        encType = (encType != null ? encType : VLAN);
-        failurePolicyType = (failurePolicyType != null ? failurePolicyType : NA);
+        ServiceFunctionChainEntity sfc = findBySfcId(sfcNetworkElement.getElementId());
 
         NetworkElementEntity inspected = makeNetworkElementEntity(inspectedPort);
-        InspectionHookEntity retVal = new InspectionHookEntity();
+        InspectionHookEntity retVal = new InspectionHookEntity(inspected, sfc);
 
-        retVal.setInspectedPort(inspected);
-        retVal.setInspectionPort(inspectionPortEntity);
-        retVal.setOrder(order);
-        retVal.setTag(tag);
-        retVal.setEncType(encType);
-        retVal.setFailurePolicyType(failurePolicyType);
-
-        inspectionPortEntity.getInspectionHooks().add(retVal);
         inspected.setInspectionHook(retVal);
 
         return retVal;
-    }
-
-    public NetworkElementEntity txNetworkElementEntityByElementId(String elementId) {
-        CriteriaBuilder cb = this.em.getCriteriaBuilder();
-
-        CriteriaQuery<NetworkElementEntity> q = cb.createQuery(NetworkElementEntity.class);
-        Root<NetworkElementEntity> r = q.from(NetworkElementEntity.class);
-        q.where(cb.equal(r.get("elementId"), elementId));
-
-        try {
-            return this.em.createQuery(q).getSingleResult();
-        } catch (Exception e) {
-            LOG.error(String.format("Finding Network Element %s ", elementId), e);
-            return null;
-        }
     }
 
     public PortPairGroupEntity findByPortPairgroupId(String ppgId) {
@@ -140,7 +110,14 @@ public class RedirectionApiUtils {
         });
     }
 
-    public InspectionPortEntity findInspPortByNetworkElements(NetworkElement ingress, NetworkElement egress) {
+    public ServiceFunctionChainEntity findBySfcId(String sfcId) {
+
+        return this.txControl.required(() -> {
+            return this.em.find(ServiceFunctionChainEntity.class, sfcId);
+        });
+    }
+
+    public InspectionPortEntity findInspectionPortByNetworkElements(NetworkElement ingress, NetworkElement egress) {
         return this.txControl.required(() -> {
 
             String ingressId = ingress != null ? ingress.getElementId() : null;
@@ -173,13 +150,6 @@ public class RedirectionApiUtils {
         });
     }
 
-    public InspectionHookEntity findInspHookByInspectedAndPort(NetworkElement inspected,
-            InspectionPortElement element) {
-        return this.txControl.required(() -> {
-            return txInspHookByInspectedAndPort(inspected, element);
-        });
-    }
-
     public InspectionPortEntity txInspectionPortEntityById(String id) {
         return this.em.find(InspectionPortEntity.class, id);
     }
@@ -190,35 +160,20 @@ public class RedirectionApiUtils {
             return;
         }
 
-        String inspectedId  = this.txControl.required(() -> {
-            InspectionHookEntity dbInspectionHook =
-                    this.em.find(InspectionHookEntity.class, hookId);
+        this.txControl.required(() -> {
+            InspectionHookEntity dbInspectionHook = this.em.find(InspectionHookEntity.class, hookId);
 
             if (dbInspectionHook == null) {
                 LOG.warn("Attempt to remove nonexistent Inspection Hook for id " + hookId);
                 return null;
             }
-
             NetworkElementEntity dbInspectedPort = dbInspectionHook.getInspectedPort();
+            ServiceFunctionChainEntity sfc = dbInspectionHook.getServiceFunctionChain();
+            sfc.getInspectionHooks().remove(dbInspectionHook);
 
-            dbInspectedPort.setInspectionHook(null);
-            dbInspectionHook.setInspectedPort(null);
-            return dbInspectedPort.getElementId();
-        });
-
-        if (inspectedId == null) {
-            return;
-        }
-
-        this.txControl.required(() -> {
-            NetworkElementEntity dbNetworkElement = this.em.find(NetworkElementEntity.class, inspectedId);
-
-            this.em.remove(dbNetworkElement);
-
-            Query q = this.em.createQuery("DELETE FROM InspectionHookEntity WHERE hook_id = :id");
-            q.setParameter("id", hookId);
-            q.executeUpdate();
-
+            this.em.remove(dbInspectionHook);
+            this.em.remove(dbInspectedPort);
+            this.em.merge(sfc);
             return null;
         });
     }
@@ -233,41 +188,40 @@ public class RedirectionApiUtils {
         });
     }
 
-    private InspectionHookEntity txInspHookByInspectedAndPort(NetworkElement inspected, InspectionPortElement element) {
-        // Paranoid
-        NetworkElement ingress = element != null ? element.getIngressPort() : null;
-        NetworkElement egress = element != null ? element.getEgressPort() : null;
+    /**
+     * Assumes arguments are not null
+     */
+    public InspectionHookEntity findInspHookByInspectedAndPort(NetworkElement inspected,
+            ServiceFunctionChainEntity inspectionSfc) {
+        LOG.info(String.format("Finding Inspection hooks by inspected %s and sfc %s", inspected,
+                inspectionSfc.getElementId()));
 
-        String inspectedId = inspected != null ? inspected.getElementId() : null;
+        return this.txControl.required(() -> {
 
-        InspectionPortEntity inspPort = findInspPortByNetworkElements(ingress, egress);
+            String inspectedId = inspected.getElementId();
+            ServiceFunctionChainEntity sfc = this.em.find(ServiceFunctionChainEntity.class,
+                    inspectionSfc.getElementId());
 
-        String portId = inspPort != null ? inspPort.getElementId() : null;
+            CriteriaBuilder cb = this.em.getCriteriaBuilder();
+            CriteriaQuery<InspectionHookEntity> criteria = cb.createQuery(InspectionHookEntity.class);
+            Root<InspectionHookEntity> root = criteria.from(InspectionHookEntity.class);
+            criteria.select(root).where(cb.and(cb.equal(root.join("inspectedPort").get("elementId"), inspectedId),
+                    cb.equal(root.join("serviceFunctionChain"), sfc)));
+            Query q = this.em.createQuery(criteria);
 
-        CriteriaBuilder cb = this.em.getCriteriaBuilder();
-        CriteriaQuery<InspectionHookEntity> criteria = cb.createQuery(InspectionHookEntity.class);
-        Root<InspectionHookEntity> root = criteria.from(InspectionHookEntity.class);
-        criteria.select(root).where(cb.and(
-                cb.equal(root.join("inspectedPort").get("elementId"), inspectedId),
-                cb.equal(root.join("inspectionPort").get("elementId"), portId)));
-        Query q= this.em.createQuery(criteria);
-
-        try {
             @SuppressWarnings("unchecked")
             List<InspectionHookEntity> inspectionHooks = q.getResultList();
             if (inspectionHooks == null || inspectionHooks.size() == 0) {
-                LOG.warn(String.format("No Inspection hooks by inspected %s and port %s", inspectedId, portId));
+                LOG.warn(String.format("No Inspection hooks by inspected %s and sfc %s", inspectedId, sfc));
                 return null;
             } else if (inspectionHooks.size() > 1) {
-                LOG.warn(String.format("Multiple results! Inspection hooks by inspected %s and port %s", inspectedId,
-                        portId));
+                String msg = String.format("Multiple results! Inspection hooks by inspected %s and sfc %s", inspectedId,
+                            sfc);
+                LOG.warn(msg);
+                throw new IllegalStateException(msg);
             }
             return inspectionHooks.get(0);
-
-        } catch (Exception e) {
-            LOG.error(String.format("Finding Inspection hooks by inspected %s and port %s", inspectedId, portId), e);
-            return null;
-        }
+        });
     }
 
     public void throwExceptionIfNullEntity(InspectionPortEntity inspectionPortTmp, InspectionPortElement inspectionPort)
@@ -283,17 +237,18 @@ public class RedirectionApiUtils {
         }
     }
 
-    private void throwExceptionIfNullElement(NetworkElement networkElement, String msg) {
-        if (networkElement == null) {
-            msg = (msg != null ? msg : "null passed for Network Element argument!");
+    public void throwExceptionIfNullElement(Element element, String type) {
+        if (element == null) {
+            String msg = String.format("null passed for %s argument!", type);
             LOG.error(msg);
             throw new IllegalArgumentException(msg);
         }
     }
 
-    private void throwExceptionIfNullElement(InspectionPortElement networkElement) {
+
+    private void throwExceptionIfNullElement(NetworkElement networkElement, String msg) {
         if (networkElement == null) {
-            String msg = "null passed for Inspection Port argument!";
+            msg = (msg != null ? msg : "null passed for Network Element argument!");
             LOG.error(msg);
             throw new IllegalArgumentException(msg);
         }

--- a/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
+++ b/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
@@ -124,10 +124,19 @@ public class RedirectionApiUtils {
         }
     }
 
-    public PortPairGroupEntity findByPortgroupId(String parentId) {
+    public PortPairGroupEntity findByPortPairgroupId(String ppgId) {
 
         return this.txControl.required(() -> {
-            return this.em.find(PortPairGroupEntity.class, parentId);
+            return this.em.find(PortPairGroupEntity.class, ppgId);
+        });
+    }
+
+    public void removePortPairGroup(String ppgId) {
+
+        this.txControl.required(() -> {
+            PortPairGroupEntity ppg = this.em.find(PortPairGroupEntity.class, ppgId);
+            this.em.remove(ppg);
+            return null;
         });
     }
 

--- a/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
+++ b/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
@@ -50,7 +50,7 @@ public class RedirectionApiUtils {
         this.txControl = txControl;
     }
 
-    public NetworkElementEntity makeNetworkElementEntity(NetworkElement networkElement) {
+    private NetworkElementEntity makeNetworkElementEntity(NetworkElement networkElement) {
         NetworkElementEntity retVal = new NetworkElementEntity();
 
         retVal.setElementId(networkElement.getElementId());
@@ -175,10 +175,6 @@ public class RedirectionApiUtils {
         return this.em.find(InspectionPortEntity.class, id);
     }
 
-    public NetworkElementEntity txNetworkElementEntityById(Long id) {
-        return this.em.find(NetworkElementEntity.class, id);
-    }
-
     public void removeSingleInspectionHook(String hookId) {
         if (hookId == null) {
             LOG.warn("Attempt to remove Inspection Hook with null id");
@@ -263,22 +259,6 @@ public class RedirectionApiUtils {
             LOG.error(String.format("Finding Inspection hooks by inspected %s and port %s", inspectedId, portId), e);
             return null;
         }
-    }
-
-    public List<InspectionHookEntity> txInspectionHookEntitiesByInspected(String inspectedId) {
-
-        CriteriaBuilder cb = this.em.getCriteriaBuilder();
-        CriteriaQuery<InspectionHookEntity> criteria = cb.createQuery(InspectionHookEntity.class);
-        Root<InspectionHookEntity> root = criteria.from(InspectionHookEntity.class);
-
-        criteria.select(root).where(cb.equal(root.join("inspectedPort").get("elementId"), inspectedId));
-
-        Query q= this.em.createQuery(criteria);
-
-        @SuppressWarnings("unchecked")
-        List<InspectionHookEntity> results = q.getResultList();
-
-        return results;
     }
 
     public void throwExceptionIfNullEntity(InspectionPortEntity inspectionPortTmp, InspectionPortElement inspectionPort)

--- a/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
+++ b/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
@@ -181,10 +181,9 @@ public class RedirectionApiUtils {
     public void removeSingleInspectionPort(String inspectionPortId) {
         this.txControl.required(() -> {
 
-          Query q = this.em.createQuery("DELETE FROM InspectionPortEntity WHERE element_id = :id");
-          q.setParameter("id", inspectionPortId);
-          q.executeUpdate();
-          return null;
+            InspectionPortEntity inspectionPort = this.em.find(InspectionPortEntity.class, inspectionPortId);
+            this.em.remove(inspectionPort);
+            return null;
         });
     }
 

--- a/src/main/resources/META-INF/create.sql
+++ b/src/main/resources/META-INF/create.sql
@@ -6,7 +6,7 @@ create table if not exists NETWORK_ELEMENT_MACADDRESSES (network_element_fk varc
 
 create table if not exists INSPECTION_PORT (element_id varchar(255) not null, ingress_fk varchar(255), egress_fk varchar(255), port_pair_group_fk varchar(255) not null, primary key (element_id) );
 
-create table if not exists INSPECTION_HOOK (hook_id varchar(255) not null, inspected_port_fk varchar(255), inspection_port_fk varchar(255), tag bigint, hook_order bigint, enc_type varchar(255), failure_policy_type varchar(255), primary key (hook_id) );
+create table if not exists INSPECTION_HOOK (hook_id varchar(255) not null, inspected_port_fk varchar(255) not null, sfc_fk varchar(255) not null, primary key (hook_id) );
 
 create table if not exists PORT_PAIR_GROUP (element_id varchar(255) not null, sfc_fk varchar(255), ppg_order bigint, primary key (element_id) );
 
@@ -17,7 +17,7 @@ alter table INSPECTION_PORT add constraint if not exists FK_INSPECTION_PORT_NETW
 alter table INSPECTION_PORT add constraint if not exists FK_INSPECTION_PORT_PPG foreign key (port_pair_group_fk) references PORT_PAIR_GROUP;
 
 alter table INSPECTION_HOOK add constraint if not exists FK_INSPECTION_HOOK_NETWORK_ELEMENT foreign key (inspected_port_fk) references NETWORK_ELEMENT;
-alter table INSPECTION_HOOK add constraint if not exists FK_INSPECTION_HOOK_INSPECTION_PORT foreign key (inspection_port_fk) references INSPECTION_PORT;
+alter table INSPECTION_HOOK add constraint if not exists FK_INSPECTION_HOOK_SFC foreign key (sfc_fk) references SERVICE_FUNCTION_CHAIN;
 
 alter table NETWORK_ELEMENT add constraint if not exists FK_NETWORK_ELEMENT_INSPECTION_HOOK foreign key (inspection_hook_fk) references INSPECTION_HOOK;
 

--- a/src/test/java/org/osc/controller/sfc/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/controller/sfc/OSGiIntegrationTest.java
@@ -455,19 +455,21 @@ public class OSGiIntegrationTest {
 
         assertEquals(elementId, foundInspectionPort.getElementId());
         String ppgId = foundInspectionPort.getParentId();
+        String ingressPortId = foundInspectionPort.getIngressPort().getElementId();
+        String egressPortId = foundInspectionPort.getEgressPort().getElementId();
 
         this.redirApi.removeInspectionPort(inspectionPortElement);
 
-        foundInspectionPort = this.txControl.required(() -> {
-            return this.em.find(InspectionPortEntity.class, elementId);
+        this.txControl.required(() -> {
+
+            assertNull(this.em.find(InspectionPortEntity.class, elementId));
+            assertNull(this.em.find(PortPairGroupEntity.class, ppgId));
+            assertNull(this.em.find(NetworkElementEntity.class, ingressPortId));
+            assertNull(this.em.find(NetworkElementEntity.class, egressPortId));
+
+            return null;
         });
 
-        PortPairGroupEntity ppg = this.txControl.required(() -> {
-            return this.em.find(PortPairGroupEntity.class, ppgId);
-        });
-
-        assertNull(foundInspectionPort);
-        assertNull(ppg);
     }
 
     @Test

--- a/src/test/java/org/osc/controller/sfc/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/controller/sfc/OSGiIntegrationTest.java
@@ -267,14 +267,14 @@ public class OSGiIntegrationTest {
     }
 
     @Test
-    public void verifyCorrectNumberOfMacsAdPortIps() throws Exception {
+    public void testDb_PersistInspectionPort_verifyCorrectNumberOfMacsAdPortIps() throws Exception {
 
         assertEquals(null, this.inspectionPort.getElementId());
 
         this.txControl.required(() -> {
             this.em.persist(this.ppg);
-            this.em.persist(this.inspectionHook);
-            return this.inspectionHook;
+            this.em.persist(this.inspectionPort);
+            return null;
         });
 
         assertNotNull(this.inspectionPort.getElementId());
@@ -290,7 +290,7 @@ public class OSGiIntegrationTest {
     }
 
     @Test
-    public void verifyHookAndPortPersistedAfterSingleHookPersistenceWithObjectGraphSetUp() {
+    public void testDb_PersistHook_verifyHookAndPortPersisted() {
 
         this.txControl.required(() -> {
             this.em.persist(this.ppg);


### PR DESCRIPTION
Remove association between inspection hook and inspection port. Inspection hook refers to the service function chain instead as defined by the Neutron SFC model.
Updated inspection hook to remove fields which are not applicable like tag/failure policy etc
Refactored unit test to make sure duplicate code is avoided.

All the methods which are not applicable in neutron SFC case like
`getInspectionHookTag(NetworkElement inspectedPort, InspectionPortElement inspectionPort)`
`getInspectionHook(NetworkElement inspectedPort, InspectionPortElement inspectionPort)`

now throw a unsupported operation exception.

